### PR TITLE
LaunchDevice Filter and Other Stuff

### DIFF
--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -188,6 +188,7 @@ namespace KerbalKonstructs
 					obj.visibleRange = float.Parse(ins.GetValue("VisibilityRange"));
 					obj.siteName = ins.GetValue("LaunchSiteName") ?? "";
 					obj.siteTransform = ins.GetValue("LaunchPadTransform") ?? "";
+                    // ASH New 15102014
                     obj.launchLength = ins.GetValue("LaunchLength") ?? "?";
                     obj.launchWidth = ins.GetValue("LaunchWidth") ?? "?";
                     obj.maxMass = ins.GetValue("MaxMass") ?? "?";
@@ -526,6 +527,8 @@ namespace KerbalKonstructs
 			showSelector = false;
 			//Make sure the editor doesn't think you're still mousing over the site selector
 			InputLockManager.RemoveControlLock("KKEditorLock");
+
+            // ASH May need another look now that left top is absolute. Now causing issues with parts info window
 		}
 
 		void doNothing()

--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -268,6 +268,10 @@ namespace KerbalKonstructs
 				Debug.Log("Saving "+model.config);
 				ConfigNode staticNode = new ConfigNode("STATIC");
 				ConfigNode modelConfig = GameDatabase.Instance.GetConfigNode(model.config);
+				
+				// ASH 17102014 WTF??? This is why configs lose additions
+				// Instances are being completely rewritten
+				// Is there a better way?
 				modelConfig.RemoveNodes("Instances");
 
 				foreach (StaticObject obj in staticDB.getObjectsFromModel(model))
@@ -291,6 +295,17 @@ namespace KerbalKonstructs
 						inst.AddValue("LaunchSiteType", obj.siteType.ToString().ToUpper());
 						if(obj.siteAuthor != "")
 							inst.AddValue("LaunchSiteAuthor", obj.siteAuthor);
+
+						// ASH 17102014 Added new instance parameters cos they were getting wiped
+						if (obj.launchDevice != "")
+							inst.AddValue("LaunchDevice", obj.launchDevice);
+						if (obj.launchLength != "")
+							inst.AddValue("LaunchLength", obj.launchLength);
+						if (obj.launchWidth != "")
+							inst.AddValue("LaunchWidth", obj.launchWidth);
+						if (obj.maxMass != "")
+							inst.AddValue("MaxMass", obj.maxMass);
+
 					}
 					modelConfig.nodes.Add(inst);
 				}

--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -93,21 +93,22 @@ namespace KerbalKonstructs
 				updateCache();
 			}
 
-			if (data.Equals(GameScenes.EDITOR) || data.Equals(GameScenes.SPH))
-			{
-				switch (data)
-				{
-					case GameScenes.SPH:
-						selector.setEditorType(SiteType.SPH);
-						break;
-					case GameScenes.EDITOR:
-						selector.setEditorType(SiteType.VAB);
-						break;
-					default:
-						selector.setEditorType(SiteType.Any);
-						break;
-				}
-			}
+            if (data.Equals(GameScenes.EDITOR) || data.Equals(GameScenes.SPH))
+            {
+                selector.Close();
+                switch (data)
+                {
+                    case GameScenes.SPH:
+                        selector.setEditorType(SiteType.SPH);
+                        break;
+                    case GameScenes.EDITOR:
+                        selector.setEditorType(SiteType.VAB);
+                        break;
+                    default:
+                        selector.setEditorType(SiteType.Any);
+                        break;
+                }
+            }
 		}
 
 		void onDominantBodyChange(GameEvents.FromToAction<CelestialBody, CelestialBody> data)
@@ -187,6 +188,10 @@ namespace KerbalKonstructs
 					obj.visibleRange = float.Parse(ins.GetValue("VisibilityRange"));
 					obj.siteName = ins.GetValue("LaunchSiteName") ?? "";
 					obj.siteTransform = ins.GetValue("LaunchPadTransform") ?? "";
+                    obj.launchLength = ins.GetValue("LaunchLength") ?? "?";
+                    obj.launchWidth = ins.GetValue("LaunchWidth") ?? "?";
+                    obj.maxMass = ins.GetValue("MaxMass") ?? "?";
+                    obj.launchDevice = ins.GetValue("LaunchDevice") ?? "Other";
 
 					if (obj.siteTransform == "" && obj.siteName != "")
 					{
@@ -222,7 +227,7 @@ namespace KerbalKonstructs
 					//KerbTown does not support group caching, for compatibility we will put these into "Ungrouped" group to be cached individually
 					obj.groupName = ins.GetValue("Group") ?? "Ungrouped";
 					//Site description
-					obj.siteDescription = ins.GetValue("LaunchSiteDescription") ?? "No description available";
+					obj.siteDescription = ins.GetValue("LaunchSiteDescription") ?? "No description available.";
 					//Site logo
 					String logo = ins.GetValue("LaunchSiteLogo") ?? "";
 					obj.siteLogo = (logo != "") ? model.path + "/" + logo : "";

--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -80,6 +80,9 @@ namespace KerbalKonstructs
 				//Assume that the Space Center is on Kerbin
 				currentBody = Util.getCelestialBody("Kerbin");
 				staticDB.onBodyChanged(currentBody);
+				// ASH 23102014
+				// Is this why space centre additions do not load sometimes? TEST ME
+				updateCache();
 			}
 			else if (!data.Equals(GameScenes.FLIGHT))//Cache everywhere except the space center or during flight
 			{

--- a/src/LaunchSites/LaunchSite.cs
+++ b/src/LaunchSites/LaunchSite.cs
@@ -11,8 +11,12 @@ namespace KerbalKonstructs.LaunchSites
 		public Texture logo;
 		public Texture icon;
 		public string description;
+        public string launchLength;
+        public string launchWidth;
+        public string maxMass;
+        public string launchDevice;
 
-		public LaunchSite(string sName, string sAuthor, SiteType sType, Texture sLogo, Texture sIcon, string sDescription)
+		public LaunchSite(string sName, string sAuthor, SiteType sType, Texture sLogo, Texture sIcon, string sDescription, string sLength, string sWidth, string sMass, string sDevice)
 		{
 			name = sName;
 			author = sAuthor;
@@ -20,6 +24,10 @@ namespace KerbalKonstructs.LaunchSites
 			logo = sLogo;
 			icon = sIcon;
 			description = sDescription;
+            launchLength = sLength;
+            launchWidth = sWidth;
+            maxMass = sMass;
+            launchDevice = sDevice;
 		}
 	}
 

--- a/src/LaunchSites/LaunchSite.cs
+++ b/src/LaunchSites/LaunchSite.cs
@@ -11,6 +11,9 @@ namespace KerbalKonstructs.LaunchSites
 		public Texture logo;
 		public Texture icon;
 		public string description;
+
+        // ASH 15102014 Added new parameters. Damn KerbTown had sucky architecture. I love legacy code.
+        // OO means I should not have to change multiple classes just to add some parameters. Gah.
         public string launchLength;
         public string launchWidth;
         public string maxMass;
@@ -24,6 +27,8 @@ namespace KerbalKonstructs.LaunchSites
 			logo = sLogo;
 			icon = sIcon;
 			description = sDescription;
+
+            // ASH 15102014 Added new parameters. Again. Sigh.
             launchLength = sLength;
             launchWidth = sWidth;
             maxMass = sMass;

--- a/src/LaunchSites/LaunchSiteManager.cs
+++ b/src/LaunchSites/LaunchSiteManager.cs
@@ -14,8 +14,8 @@ namespace KerbalKonstructs.LaunchSites
 		static LaunchSiteManager()
 		{
 			//Accepting contributions to change my horrible descriptions
-			launchSites.Add(new LaunchSite("Runway", "Squad", SiteType.SPH, GameDatabase.Instance.GetTexture("medsouz/KerbalKonstructs/Assets/KSCRunway", false), null, "The KSC runway is a concrete runway measuring about 2.5km long and 70m wide, on a magnetic heading of 90/270. It is not uncommon to see burning chunks of metal sliding across the surface."));
-			launchSites.Add(new LaunchSite("LaunchPad", "Squad", SiteType.VAB, GameDatabase.Instance.GetTexture("medsouz/KerbalKonstructs/Assets/KSCLaunchpad", false), null, "The KSC launchpad is a platform used to fire screaming Kerbals into the kosmos. There was a tower here at one point but for some reason nobody seems to know where it went..."));
+			launchSites.Add(new LaunchSite("KSC Runway", "Squad", SiteType.SPH, GameDatabase.Instance.GetTexture("medsouz/KerbalKonstructs/Assets/KSCRunway", false), null, "The KSC runway is a concrete runway measuring about 2.5km long and 70m wide, on a magnetic heading of 90/270. It is not uncommon to see burning chunks of metal sliding across the surface.", "X", "X", "NA", "Runway"));
+            launchSites.Add(new LaunchSite("KSC LaunchPad", "Squad", SiteType.VAB, GameDatabase.Instance.GetTexture("medsouz/KerbalKonstructs/Assets/KSCLaunchpad", false), null, "The KSC launchpad is a platform used to fire screaming Kerbals into the kosmos. There was a tower here at one point but for some reason nobody seems to know where it went...", "X", "X", "NA", "RocketPad"));
 		}
 
 		//This is pretty much ripped from KerbTown, sorry
@@ -59,7 +59,7 @@ namespace KerbalKonstructs.LaunchSites
 								logo = GameDatabase.Instance.GetTexture(obj.siteLogo, false);
 							if (obj.siteIcon != "")
 								icon = GameDatabase.Instance.GetTexture(obj.siteIcon, false);
-							launchSites.Add(new LaunchSite(obj.siteName, (obj.siteAuthor != "") ? obj.siteAuthor : obj.model.author, obj.siteType, logo, icon, obj.siteDescription));
+							launchSites.Add(new LaunchSite(obj.siteName, (obj.siteAuthor != "") ? obj.siteAuthor : obj.model.author, obj.siteType, logo, icon, obj.siteDescription, obj.launchLength, obj.launchWidth, obj.maxMass, obj.launchDevice));
 							Debug.Log("Created launch site \"" + newFacility.name + "\" with transform " + obj.siteName + "/" + obj.siteTransform);
 						}
 						else
@@ -81,19 +81,45 @@ namespace KerbalKonstructs.LaunchSites
 			}
 		}
 
-		public static List<LaunchSite> getLaunchSites()
+        public static List<LaunchSite> getLaunchSites(String usedFilter = "ALL")
 		{
-			return launchSites;
+            List<LaunchSite> sites = new List<LaunchSite>();
+            foreach (LaunchSite site in launchSites)
+            {
+                if (usedFilter.Equals("ALL"))
+                {
+                    sites.Add(site);
+                }
+                else
+                {
+                    if (site.launchDevice.Equals(usedFilter))
+                    {
+                        sites.Add(site);
+                    }
+                }
+            }
+            return sites;
+			//return launchSites;
 		}
 
-		public static List<LaunchSite> getLaunchSites(SiteType type, Boolean allowAny = true)
+		public static List<LaunchSite> getLaunchSites(SiteType type, Boolean allowAny = true, String appliedFilter = "ALL")
 		{
 			List<LaunchSite> sites = new List<LaunchSite>();
 			foreach (LaunchSite site in launchSites)
 			{
 				if(site.type.Equals(type) || (site.type.Equals(SiteType.Any) && allowAny))
 				{
-					sites.Add(site);
+                    if (appliedFilter.Equals("ALL"))
+                    {
+                        sites.Add(site);
+                    }
+                    else
+                    {
+                        if (site.launchDevice.Equals(appliedFilter))
+                        {
+                            sites.Add(site);
+                        }
+                    }
 				}
 			}
 			return sites;

--- a/src/LaunchSites/LaunchSiteManager.cs
+++ b/src/LaunchSites/LaunchSiteManager.cs
@@ -14,8 +14,11 @@ namespace KerbalKonstructs.LaunchSites
 		static LaunchSiteManager()
 		{
 			//Accepting contributions to change my horrible descriptions
-			launchSites.Add(new LaunchSite("KSC Runway", "Squad", SiteType.SPH, GameDatabase.Instance.GetTexture("medsouz/KerbalKonstructs/Assets/KSCRunway", false), null, "The KSC runway is a concrete runway measuring about 2.5km long and 70m wide, on a magnetic heading of 90/270. It is not uncommon to see burning chunks of metal sliding across the surface.", "X", "X", "NA", "Runway"));
-            launchSites.Add(new LaunchSite("KSC LaunchPad", "Squad", SiteType.VAB, GameDatabase.Instance.GetTexture("medsouz/KerbalKonstructs/Assets/KSCLaunchpad", false), null, "The KSC launchpad is a platform used to fire screaming Kerbals into the kosmos. There was a tower here at one point but for some reason nobody seems to know where it went...", "X", "X", "NA", "RocketPad"));
+
+            // ASH 15102014
+            // Added new parameters. Also do not change the name again. Apparently they are unique IDs. Squad, you suck sometimes.
+			launchSites.Add(new LaunchSite("Runway", "Squad", SiteType.SPH, GameDatabase.Instance.GetTexture("medsouz/KerbalKonstructs/Assets/KSCRunway", false), null, "The KSC runway is a concrete runway measuring about 2.5km long and 70m wide, on a magnetic heading of 90/270. It is not uncommon to see burning chunks of metal sliding across the surface.", "X", "X", "NA", "Runway"));
+            launchSites.Add(new LaunchSite("LaunchPad", "Squad", SiteType.VAB, GameDatabase.Instance.GetTexture("medsouz/KerbalKonstructs/Assets/KSCLaunchpad", false), null, "The KSC launchpad is a platform used to fire screaming Kerbals into the kosmos. There was a tower here at one point but for some reason nobody seems to know where it went...", "X", "X", "NA", "RocketPad"));
 		}
 
 		//This is pretty much ripped from KerbTown, sorry
@@ -59,6 +62,8 @@ namespace KerbalKonstructs.LaunchSites
 								logo = GameDatabase.Instance.GetTexture(obj.siteLogo, false);
 							if (obj.siteIcon != "")
 								icon = GameDatabase.Instance.GetTexture(obj.siteIcon, false);
+
+                            // ASH 15102014 Added new parameters
 							launchSites.Add(new LaunchSite(obj.siteName, (obj.siteAuthor != "") ? obj.siteAuthor : obj.model.author, obj.siteType, logo, icon, obj.siteDescription, obj.launchLength, obj.launchWidth, obj.maxMass, obj.launchDevice));
 							Debug.Log("Created launch site \"" + newFacility.name + "\" with transform " + obj.siteName + "/" + obj.siteTransform);
 						}
@@ -83,6 +88,7 @@ namespace KerbalKonstructs.LaunchSites
 
         public static List<LaunchSite> getLaunchSites(String usedFilter = "ALL")
 		{
+            // ASH 15102014 Added handling for new LaunchDevice filter
             List<LaunchSite> sites = new List<LaunchSite>();
             foreach (LaunchSite site in launchSites)
             {
@@ -104,6 +110,7 @@ namespace KerbalKonstructs.LaunchSites
 
 		public static List<LaunchSite> getLaunchSites(SiteType type, Boolean allowAny = true, String appliedFilter = "ALL")
 		{
+            // ASH 15102014 Added handling for new LaunchDevice filter
 			List<LaunchSite> sites = new List<LaunchSite>();
 			foreach (LaunchSite site in launchSites)
 			{

--- a/src/StaticObjects/StaticDatabase.cs
+++ b/src/StaticObjects/StaticDatabase.cs
@@ -40,6 +40,8 @@ namespace KerbalKonstructs.StaticObjects
 
 		public void cacheAll()
 		{
+			// ASH 23102014 Does this handle activeBodyName null?
+			// Testing suggests it is fine. No intrusions in the VAB or SPH so extra space centre stuff is being deactivated
 			if (groupList.ContainsKey(activeBodyName))
 			{
 				foreach (StaticGroup group in groupList[KerbalKonstructs.instance.getCurrentBody().bodyName].Values)
@@ -79,6 +81,10 @@ namespace KerbalKonstructs.StaticObjects
 			}
 			else
 			{
+				// ASH 23102014 Does cacheAll actually handle activeBodyName being null?
+				// Are these two lines the wrong way round?
+				// No this must be working because no intrusions appearing in the VAB or SPH
+				// Leave it alone Ash
 				cacheAll();
 				activeBodyName = "";
 			}

--- a/src/StaticObjects/StaticObject.cs
+++ b/src/StaticObjects/StaticObject.cs
@@ -23,6 +23,11 @@ namespace KerbalKonstructs.StaticObjects
 		public string siteLogo;
 		public string siteIcon;
 		public string siteAuthor;
+        public string launchLength;
+        public string launchWidth;
+        public string maxMass;
+        public string launchDevice;
+
 		public LaunchSites.SiteType siteType;
 
 		public Boolean editing;

--- a/src/StaticObjects/StaticObject.cs
+++ b/src/StaticObjects/StaticObject.cs
@@ -23,6 +23,8 @@ namespace KerbalKonstructs.StaticObjects
 		public string siteLogo;
 		public string siteIcon;
 		public string siteAuthor;
+
+        // ASH 15102014 Added new parameters
         public string launchLength;
         public string launchWidth;
         public string maxMass;

--- a/src/UI/EditorGUI.cs
+++ b/src/UI/EditorGUI.cs
@@ -43,7 +43,7 @@ namespace KerbalKonstructs.UI
 		}
 
 		Rect toolRect = new Rect(50, 50, 336, 250);
-		Rect editorRect = new Rect(50, 350, 500, 295);
+		Rect editorRect = new Rect(50, 100, 700, 400);
 		Rect siteEditorRect = new Rect(400, 50, 330, 350);
 
 		private GUIStyle listStyle = new GUIStyle();
@@ -185,27 +185,31 @@ namespace KerbalKonstructs.UI
 
 		void drawEditorWindow(int id)
 		{
-			GUILayout.BeginArea(new Rect(10, 25, 240, 265));
-				GUILayout.BeginHorizontal();
+			GUILayout.BeginArea(new Rect(10, 25, 125, 365));
+				//GUILayout.BeginHorizontal();
 					GUI.enabled = !creating;
 					if (GUILayout.Button("New Object", GUILayout.Width(115)))
 						creating = true;
-					GUILayout.Space(5);
+					//GUILayout.Space(5);
 					GUI.enabled = creating;
 					if (GUILayout.Button("Existing Object", GUILayout.Width(115)))
 						creating = false;
 					GUI.enabled = true;
-				GUILayout.EndHorizontal();
+				//GUILayout.EndHorizontal();
+                    GUILayout.Space(10);
 				if (GUILayout.Button("Save Objects", GUILayout.Width(115)))
 					KerbalKonstructs.instance.saveObjects();
 			GUILayout.EndArea();
-			GUILayout.BeginArea(new Rect(255, 25, 240, 265));
+			GUILayout.BeginArea(new Rect(135, 25, 540, 365));
 				scrollPos = GUILayout.BeginScrollView(scrollPos);
 				if (creating)
 				{
 					foreach (StaticModel model in KerbalKonstructs.instance.getStaticDB().getModels())
 					{
-						if (GUILayout.Button(model.meshName + " [" + model.path + "]"))
+                        String[] modelpaths = model.path.Split('/');
+                        String firstpath = modelpaths.Length > 0 ? modelpaths[0] : model.path;
+
+						if (GUILayout.Button(model.meshName + " [" + firstpath + "]"))
 						{
 							StaticObject obj = new StaticObject();
 							obj.gameObject = GameDatabase.Instance.GetModel(model.path + "/" + model.meshName);
@@ -233,8 +237,10 @@ namespace KerbalKonstructs.UI
 				{
 					foreach (StaticObject obj in KerbalKonstructs.instance.getStaticDB().getAllStatics())
 					{
+                        String[] modelpaths = obj.model.path.Split('/');
+                        String firstpath = modelpaths.Length > 0 ? modelpaths[0] : obj.model.path;
 						GUI.enabled = !(obj == selectedObject);
-						if (GUILayout.Button(((obj.siteName != "") ? obj.siteName + "(" + obj.model.meshName + ")" : obj.model.meshName) + " [" + obj.model.path + "]"))
+						if (GUILayout.Button(((obj.siteName != "") ? obj.siteName + "(" + obj.model.meshName + ")" : obj.model.meshName) + " [" + firstpath + "]"))
 						{
 							//TODO: Move PQS target to object position
 							KerbalKonstructs.instance.selectObject(obj);

--- a/src/UI/EditorGUI.cs
+++ b/src/UI/EditorGUI.cs
@@ -59,6 +59,8 @@ namespace KerbalKonstructs.UI
 
 		//TODO: rewrite this to use magical GUILayout code
 		//I wish I knew GUILayout was a thing when I made this :(
+
+        // ASH I feel your pain. Want me to rewrite this?
 		void drawToolWindow(int windowID)
 		{
 			GUI.Label(new Rect(21, 30, 203, 25), "Position");
@@ -185,6 +187,7 @@ namespace KerbalKonstructs.UI
 
 		void drawEditorWindow(int id)
 		{
+            // ASH 15102014 Layout changes. medsouz, let me know if you like.
 			GUILayout.BeginArea(new Rect(10, 25, 125, 365));
 				//GUILayout.BeginHorizontal();
 					GUI.enabled = !creating;
@@ -206,6 +209,7 @@ namespace KerbalKonstructs.UI
 				{
 					foreach (StaticModel model in KerbalKonstructs.instance.getStaticDB().getModels())
 					{
+                        // ASH 15102014 Removed redundant info from the path. Only need to know the content mod really
                         String[] modelpaths = model.path.Split('/');
                         String firstpath = modelpaths.Length > 0 ? modelpaths[0] : model.path;
 
@@ -318,6 +322,7 @@ namespace KerbalKonstructs.UI
 			GUILayout.EndHorizontal();
 			siteTypeMenu.Show(rect);
 			GUI.DragWindow(new Rect(0, 0, 10000, 10000));
+            // ASH Worth considering doing this for the launch selector?
 		}
 
 		public void updateSelection(StaticObject obj)

--- a/src/UI/LaunchSiteSelectorGUI.cs
+++ b/src/UI/LaunchSiteSelectorGUI.cs
@@ -97,12 +97,14 @@ namespace KerbalKonstructs.UI
 			{
 				GUILayout.BeginArea(new Rect(385, 25, 310, 550));
 					GUILayout.Label(selectedSite.logo, GUILayout.Height(280));
-                    GUILayout.Label(selectedSite.name + " By " + selectedSite.author, GUILayout.ExpandWidth(true));
+					// ASH 17102014 Still trying to find the odd centering bug. I think GUILayout is just unreliable crap.
+                    GUILayout.Label(selectedSite.name + " By " + selectedSite.author);
 					descriptionScrollPosition = GUILayout.BeginScrollView(descriptionScrollPosition);
 						GUILayout.Label(selectedSite.description);
 					GUILayout.EndScrollView();
                     GUILayout.Label("Length: " + selectedSite.launchLength + " m | Width: " + selectedSite.launchWidth + " m"); 
                     GUILayout.Label("Recommended Mass: " + selectedSite.maxMass + " t");
+					// ASH STUB for adding recovery rating and launch cost modifier feature in future
                     GUILayout.Label("Recovery Rating: A-F | Launch Cost: X%");
                     // ASH STUB for adding openclose feature in future
                     // Button label should be determined by whether location is open or close
@@ -116,6 +118,9 @@ namespace KerbalKonstructs.UI
                         // unless maybe have a second column of buttons for just pulling up info - ?
                         // No will not work selected launch site is indicated by being disabled... hmmm
                         // Funds should be charged for opening a location and gained for closing a location
+
+                        // Funding.Instance.AddFunds(X, TransactionReasons.X);
+                        Double CurrentFunds = Funding.Instance.Funds;
                     }
                 // Why does not GUILayout have an alignment method? I wanna center labels. Unity you suck.
 				GUILayout.EndArea();
@@ -152,7 +157,6 @@ namespace KerbalKonstructs.UI
         // ASH and Ravencrow 15102014
         // Need to handle if Launch Selector is still open when switching from VAB to from SPH
         // otherwise abuse possible!
-        // THIS HAS NOT BEEN TESTED YET
         public void Close()
         {
             sites = null;

--- a/src/UI/LaunchSiteSelectorGUI.cs
+++ b/src/UI/LaunchSiteSelectorGUI.cs
@@ -10,7 +10,7 @@ namespace KerbalKonstructs.UI
 		LaunchSite selectedSite;
 		private SiteType editorType = SiteType.Any;
 
-		Rect windowRect = new Rect(((Screen.width - Camera.main.rect.x) / 2) + Camera.main.rect.x - 125, (Screen.height / 2 - 250), 600, 500);
+		Rect windowRect = new Rect(300, 50, 700, 580);
 
 		public void drawSelector()
 		{
@@ -29,19 +29,60 @@ namespace KerbalKonstructs.UI
 
 		public Vector2 sitesScrollPosition;
 		public Vector2 descriptionScrollPosition;
-
-		public void drawSelectorWindow(int id)
+        
+        // Changed scope so we can change it by filter ASH 14102014
+        public List<LaunchSite> sites;
+		
+        public void drawSelectorWindow(int id)
 		{
-			GUILayout.BeginArea(new Rect(10, 25, 270, 465));
+            GUILayout.BeginArea(new Rect(10, 25, 370, 550));
+                GUILayout.BeginHorizontal();
+                if (GUILayout.Button("RocketPads", GUILayout.Width(80)))
+                {
+                    sites = (editorType == SiteType.Any) ? LaunchSiteManager.getLaunchSites() : LaunchSiteManager.getLaunchSites(editorType, true, "RocketPad");
+                }
+                GUILayout.Space(2);
+                if (GUILayout.Button("Runways", GUILayout.Width(73)))
+                {
+                    sites = (editorType == SiteType.Any) ? LaunchSiteManager.getLaunchSites() : LaunchSiteManager.getLaunchSites(editorType, true, "Runway");
+                }
+                GUILayout.Space(2);
+                if (GUILayout.Button("Helipads", GUILayout.Width(73)))
+                {
+                    sites = (editorType == SiteType.Any) ? LaunchSiteManager.getLaunchSites() : LaunchSiteManager.getLaunchSites(editorType, true, "Helipad");
+                }
+                GUILayout.Space(2);
+                if (GUILayout.Button("Other", GUILayout.Width(65)))
+                {
+                    sites = (editorType == SiteType.Any) ? LaunchSiteManager.getLaunchSites() : LaunchSiteManager.getLaunchSites(editorType, true, "Other");
+                }
+                GUILayout.Space(2);
+                if (GUILayout.Button("ALL", GUILayout.Width(45)))
+                {
+                    sites = (editorType == SiteType.Any) ? LaunchSiteManager.getLaunchSites() : LaunchSiteManager.getLaunchSites(editorType, true, "ALL");
+                }
+                GUILayout.EndHorizontal();
+
+                GUILayout.Space(10);
 				sitesScrollPosition = GUILayout.BeginScrollView(sitesScrollPosition);
-				List<LaunchSite> sites = (editorType == SiteType.Any) ? LaunchSiteManager.getLaunchSites() : LaunchSiteManager.getLaunchSites(editorType);
+
+                if (sites == null) sites = (editorType == SiteType.Any) ? LaunchSiteManager.getLaunchSites() : LaunchSiteManager.getLaunchSites(editorType, true, "ALL");
+
 				foreach (LaunchSite site in sites)
 				{
 					GUI.enabled = !(selectedSite == site);
 					if (GUILayout.Button(site.name, GUILayout.Height(30)))
 					{
 						selectedSite = site;
+                        // Only do this if site is OPEN - if OPEN then
 						LaunchSiteManager.setLaunchSite(site);
+                        // else
+                        // print up a message that this site is closed
+                        // and auto-deselect
+                        // HOW??
+                        //Like this?
+                        //selectedSite = LaunchSiteManager.getLaunchSites(editorType)[0];
+                        // No probably not cos filters
 					}
 				}
 				GUILayout.EndScrollView();
@@ -52,22 +93,40 @@ namespace KerbalKonstructs.UI
 
 			if (selectedSite != null)
 			{
-				GUILayout.BeginArea(new Rect(290, 25, 300, 465));
+				GUILayout.BeginArea(new Rect(385, 25, 310, 550));
 					GUILayout.Label(selectedSite.logo, GUILayout.Height(280));
-					GUILayout.Label(selectedSite.name);
-					GUILayout.Label("By "+selectedSite.author);
+                    GUILayout.Label(selectedSite.name + " By " + selectedSite.author, GUILayout.ExpandWidth(true));
 					descriptionScrollPosition = GUILayout.BeginScrollView(descriptionScrollPosition);
 						GUILayout.Label(selectedSite.description);
 					GUILayout.EndScrollView();
+                    GUILayout.Label("Length: " + selectedSite.launchLength + " m | Width: " + selectedSite.launchWidth + " m"); 
+                    GUILayout.Label("Recommended Mass: " + selectedSite.maxMass + " t");
+                    GUILayout.Label("Recovery Rating: A-F | Launch Cost: X%");
+                    // Button label should be determined by whether location is open or close
+                    if (GUILayout.Button("OPEN/CLOSE for X Funds", GUILayout.ExpandWidth(true)))
+                    {
+                        // Complex shit. Needs to keep track of whether a location
+                        // is open or closed per save
+                        // Launch selector should not allow launching from a location that is not open
+                        // CANNOT disable closed locations cos we need the second window populated
+                        // unless maybe have a second column of buttons for just pulling up info - ?
+                        // No will not work selected launch site is indicated by being disabled... hmmm
+                        // Funds should be charged for opening a location and gained for closing a location
+                    }
 				GUILayout.EndArea();
 			}
 			else
 			{
-				if (LaunchSiteManager.getLaunchSites().Count > 0)
-				{
-					selectedSite = LaunchSiteManager.getLaunchSites(editorType)[0];
-					LaunchSiteManager.setLaunchSite(selectedSite);
-				}
+                if (LaunchSiteManager.getLaunchSites().Count > 0)
+                {
+                    selectedSite = LaunchSiteManager.getLaunchSites(editorType)[0];
+                    LaunchSiteManager.setLaunchSite(selectedSite);
+                }
+                else
+                {
+                        // TODO Need to handle list filter not having any entries and thus falling back to KSC runway
+                        // or launchpad
+                }
 			}
 		}
 
@@ -83,5 +142,10 @@ namespace KerbalKonstructs.UI
 				LaunchSiteManager.setLaunchSite(selectedSite);
 			}
 		}
+
+        public void Close()
+        {
+            sites = null;
+        }
 	}
 }

--- a/src/UI/LaunchSiteSelectorGUI.cs
+++ b/src/UI/LaunchSiteSelectorGUI.cs
@@ -29,12 +29,13 @@ namespace KerbalKonstructs.UI
 
 		public Vector2 sitesScrollPosition;
 		public Vector2 descriptionScrollPosition;
-        
-        // Changed scope so we can change it by filter ASH 14102014
+
+        // ASH 14102014 Changed scope so we can change it by LaunchDevice filter
         public List<LaunchSite> sites;
 		
         public void drawSelectorWindow(int id)
 		{
+            // ASH 14102014 LaunchDevice filter handling added. Sloppy repeating of code Ash. Learn to code.
             GUILayout.BeginArea(new Rect(10, 25, 370, 550));
                 GUILayout.BeginHorizontal();
                 if (GUILayout.Button("RocketPads", GUILayout.Width(80)))
@@ -74,6 +75,7 @@ namespace KerbalKonstructs.UI
 					if (GUILayout.Button(site.name, GUILayout.Height(30)))
 					{
 						selectedSite = site;
+                        // ASH Commentary on adding openclose feature in future
                         // Only do this if site is OPEN - if OPEN then
 						LaunchSiteManager.setLaunchSite(site);
                         // else
@@ -102,9 +104,11 @@ namespace KerbalKonstructs.UI
                     GUILayout.Label("Length: " + selectedSite.launchLength + " m | Width: " + selectedSite.launchWidth + " m"); 
                     GUILayout.Label("Recommended Mass: " + selectedSite.maxMass + " t");
                     GUILayout.Label("Recovery Rating: A-F | Launch Cost: X%");
+                    // ASH STUB for adding openclose feature in future
                     // Button label should be determined by whether location is open or close
                     if (GUILayout.Button("OPEN/CLOSE for X Funds", GUILayout.ExpandWidth(true)))
                     {
+                        // ASH Commentary on adding openclose feature in future
                         // Complex shit. Needs to keep track of whether a location
                         // is open or closed per save
                         // Launch selector should not allow launching from a location that is not open
@@ -113,6 +117,7 @@ namespace KerbalKonstructs.UI
                         // No will not work selected launch site is indicated by being disabled... hmmm
                         // Funds should be charged for opening a location and gained for closing a location
                     }
+                // Why does not GUILayout have an alignment method? I wanna center labels. Unity you suck.
 				GUILayout.EndArea();
 			}
 			else
@@ -124,8 +129,9 @@ namespace KerbalKonstructs.UI
                 }
                 else
                 {
-                        // TODO Need to handle list filter not having any entries and thus falling back to KSC runway
-                        // or launchpad
+                        // ASH
+                        // Maybe TODO Need to handle list filter not having any entries and thus falling back to KSC runway
+                        // or launchpad. Need to think about this more.
                 }
 			}
 		}
@@ -143,6 +149,10 @@ namespace KerbalKonstructs.UI
 			}
 		}
 
+        // ASH and Ravencrow 15102014
+        // Need to handle if Launch Selector is still open when switching from VAB to from SPH
+        // otherwise abuse possible!
+        // THIS HAS NOT BEEN TESTED YET
         public void Close()
         {
             sites = null;

--- a/src/Util.cs
+++ b/src/Util.cs
@@ -16,5 +16,14 @@ namespace KerbalKonstructs
 			Debug.Log("Couldn't find body \"" + name + "\"");
 			return null;
 		}
+
+        // ASH Going to need this for persistence
+        public static String GetRootPath()
+        {
+            String path = KSPUtil.ApplicationRootPath;
+            path = path.Replace("\\", "/");
+            if (path.EndsWith("/")) path = path.Substring(0, path.Length - 1);
+            return path;
+        }
 	}
 }


### PR DESCRIPTION
Added four optional new info fields to instances: LaunchWidth, LaunchLength, MaxMass, LaunchDevice

LaunchDevice is used with a new filter in the launch selector.

In the instance:
LaunchWidth: X in meters. The m will be added in the selector.
LaunchLength: X in meters. The m will be added in the selector.
MaxMass: X in tons. The t will be added in the selector. This is a recommendation and not enforced.

These default to ?. They're strings, not integers, so feel free to abuse them.

LaunchDevice = option

LaunchDevice options are:
RocketPad
Runway
Helipad
Other

Defaults to Other.

No quotation marks.

Added some stubs and commentary for future features. So that means a button that does not do anything yet in the launch selector.
Changed the layout of the launch selector and editor a bit, for usability. Personal taste stuff - medsouz axe this if you hate it.
