### PR TITLE
Fixed recovery bug

### DIFF
--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -122,9 +122,9 @@ namespace KerbalKonstructs
 			if (data.Equals(GameScenes.FLIGHT))
 			{
 				Debug.Log("KK: onLevelWasLoaded is FLIGHT");
-				Debug.Log("KK: onLevelWasLoaded calling onBodyChanged with " + currentBody.bodyName);
-				staticDB.onBodyChanged(currentBody);
-				// ASH 03112014 Trying to fix recovery issue
+				// ASH 03112014 Fix recovery issue and remove redundant code.
+				// Debug.Log("KK: onLevelWasLoaded calling onBodyChanged with " + currentBody.bodyName);
+				// staticDB.onBodyChanged(currentBody);
 				updateCache();
 				Debug.Log("KK: Invoking updateCache");
 				InvokeRepeating("updateCache", 0, 1);
@@ -186,7 +186,6 @@ namespace KerbalKonstructs
 
 		void onDominantBodyChange(GameEvents.FromToAction<CelestialBody, CelestialBody> data)
 		{
-			// ASH 03112014 Is this wrong? Nope.
 			currentBody = data.to;
 			Debug.Log("KK: event onDominantBodyChange to " + data.to.bodyName);
 			staticDB.onBodyChanged(data.to);

--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -83,13 +83,14 @@ namespace KerbalKonstructs
 			loadObjects();
 			// ASH 01112014 Toggle on and off for the flight scene only
 			//InvokeRepeating("updateCache", 0, 1);
-			SpaceCenterManager.setKSC();
+			//SpaceCenterManager.setKSC();
 		}
 
 		void OnVesselRecoveryRequested(Vessel data)
 		{
-			SpaceCenter csc = SpaceCenterManager.getClosestSpaceCenter(data.gameObject.transform.position);
-			SpaceCenter.Instance = csc;
+			Debug.Log("KK: event onVesselRecoveryRequested");
+			//SpaceCenter csc = SpaceCenterManager.getClosestSpaceCenter(data.gameObject.transform.position);
+			//SpaceCenter.Instance = csc;
 		}
 
 		void OnGUIAppLauncherReady()
@@ -123,6 +124,8 @@ namespace KerbalKonstructs
 				Debug.Log("KK: onLevelWasLoaded is FLIGHT");
 				Debug.Log("KK: onLevelWasLoaded calling onBodyChanged with " + currentBody.bodyName);
 				staticDB.onBodyChanged(currentBody);
+				// ASH 03112014 Trying to fix recovery issue
+				updateCache();
 				Debug.Log("KK: Invoking updateCache");
 				InvokeRepeating("updateCache", 0, 1);
 				something = false;
@@ -138,8 +141,9 @@ namespace KerbalKonstructs
 				Debug.Log("KK: onLevelWasLoaded is SPACECENTER");
 				//Assume that the Space Center is on Kerbin
 				
-				// ASH This is wrong
-				// currentBody = KKAPI.getCelestialBody("Kerbin")
+				// ASH This is wrong IS IT?
+				currentBody = KKAPI.getCelestialBody("Kerbin");
+				// staticDB.onBodyChanged(currentBody);
 				Debug.Log("KK: onLevelWasLoaded calling onBodyChanged with Kerbin");
 
 				// ASH This is right
@@ -177,20 +181,20 @@ namespace KerbalKonstructs
 				Debug.Log("KK: onLevelWasLoaded is SOMEOTHERSCENE");
 				Debug.Log("KK: onLevelWasLoaded calling onBodyChanged with NULL");
 				staticDB.onBodyChanged(null);
-				Debug.Log("KK: onLevelWasLoaded calling updateCache");
-				updateCache();
 			}
 		}
 
 		void onDominantBodyChange(GameEvents.FromToAction<CelestialBody, CelestialBody> data)
 		{
+			// ASH 03112014 Is this wrong? Nope.
 			currentBody = data.to;
-			Debug.Log("KK: event onDominantBodyChange to " + currentBody.bodyName);
+			Debug.Log("KK: event onDominantBodyChange to " + data.to.bodyName);
 			staticDB.onBodyChanged(data.to);
 		}
 
 		public void updateCache()
 		{
+			Debug.Log("KK: updateCache()");
 			if (HighLogic.LoadedSceneIsGame)
 			{
 				Vector3 playerPos = Vector3.zero;
@@ -207,6 +211,7 @@ namespace KerbalKonstructs
 					//HACKY: if there is no vessel use the camera, this could cause some issues
 					playerPos = Camera.main.transform.position;
 				}
+				Debug.Log("KK: playerPos is" + playerPos);
 				staticDB.updateCache(playerPos);
 			}
 		}

--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -107,12 +107,16 @@ namespace KerbalKonstructs
 		// ASH 01112014 Lots of debug
 		void onLevelWasLoaded(GameScenes data)
 		{
-			Debug.Log("KK: event onLevelWasLoaded");
+			// ASH 04112014 Likely responsible for camera locks in the flight and space centre scenes
+			// For some reason the lock is not reliably dropped... I think.
+			Debug.Log("KK: event onLevelWasLoaded. Drop selector input lock.");
+			InputLockManager.RemoveControlLock("KKEditorLock");
 			
 			if (selectedObject != null)
 			{
-				Debug.Log("KK: Deselecting an object");
+				Debug.Log("KK: Deselecting an object.");
 				deselectObject(false);
+				// ASH 04112014 Why?
 				camControl.active = false;
 			}
 

--- a/src/StaticObjects/StaticDatabase.cs
+++ b/src/StaticObjects/StaticDatabase.cs
@@ -73,6 +73,7 @@ namespace KerbalKonstructs.StaticObjects
 		public void loadObjectsForBody(String bodyName)
 		{
 			activeBodyName = bodyName;
+			Debug.Log("KK: loadObjectsForBody() bodyName is " + bodyName);
 			if (groupList.ContainsKey(bodyName))
 			{
 				foreach (KeyValuePair<String, StaticGroup> bodyGroups in groupList[bodyName])
@@ -90,14 +91,18 @@ namespace KerbalKonstructs.StaticObjects
 		{
 			if (body != null)
 			{
+				Debug.Log("KK: onBodyChanged() body.bodyName is " + body.bodyName);
+				Debug.Log("KK: onBodyChanged() activebodyName is " + activeBodyName);
 				if (body.bodyName != activeBodyName)
 				{
+					Debug.Log("KK: onBodyChanged() calls cacheAll() then loadObjectsForBody()");
 					cacheAll();
 					loadObjectsForBody(body.bodyName);
 				}
 			}
 			else
 			{
+				Debug.Log("KK: onBodyChanged() calls cacheAll() THEN sets activeBodyName blank");
 				cacheAll();
 				activeBodyName = "";
 			}
@@ -105,6 +110,7 @@ namespace KerbalKonstructs.StaticObjects
 
 		public void updateCache(Vector3 playerPos)
 		{
+			Debug.Log("KK: StaticDatabase.updateCache() - " + activeBodyName);
 			if (groupList.ContainsKey(activeBodyName))
 			{
 				foreach (StaticGroup group in groupList[activeBodyName].Values)
@@ -115,7 +121,7 @@ namespace KerbalKonstructs.StaticObjects
 						Boolean active = dist < group.getVisibilityRange();
 						if (active != group.active && active == false)
 						{
-							Debug.Log("Caching group " + group.getGroupName());
+							Debug.Log("KK: Caching group " + group.getGroupName());
 							group.cacheAll();
 						}
 						group.active = active;
@@ -141,12 +147,12 @@ namespace KerbalKonstructs.StaticObjects
 				}
 				else
 				{
-					Debug.Log("Group not found! " + groupName);
+					Debug.Log("KK: Group not found! " + groupName);
 				}
 			}
 			else
 			{
-				Debug.Log("Body not found! " + bodyName);
+				Debug.Log("KK: Body not found! " + bodyName);
 			}
 		}
 
@@ -187,10 +193,10 @@ namespace KerbalKonstructs.StaticObjects
 			if (objList.Count >= 1)
 			{
 				if (objList.Count > 1)
-					Debug.Log("WARNING: More than one StaticObject references to GameObject " + gameObject.name);
+					Debug.Log("KK: WARNING: More than one StaticObject references to GameObject " + gameObject.name);
 				return objList[0];
 			}
-			Debug.Log("WARNING: StaticObject doesn't exist for " + gameObject.name);
+			Debug.Log("KK: WARNING: StaticObject doesn't exist for " + gameObject.name);
 			return null;
 		}
 	}

--- a/src/StaticObjects/StaticGroup.cs
+++ b/src/StaticObjects/StaticGroup.cs
@@ -68,7 +68,7 @@ namespace KerbalKonstructs.StaticObjects
 				bool visible = (dist < (float) obj.getSetting("VisibilityRange"));
 				if (visible != obj.gameObject.activeSelf)
 				{
-					//Debug.Log("Setting " + obj.gameObject.name + " to visible=" + visible);
+					Debug.Log("Setting " + obj.gameObject.name + " to visible=" + visible);
 					obj.gameObject.SetActive(visible);
 				}
 			}
@@ -98,7 +98,7 @@ namespace KerbalKonstructs.StaticObjects
 			}
 			else
 			{
-				Debug.Log("Tried to delete an object that doesn't exist in this group!");
+				Debug.Log("KK: Tried to delete an object that doesn't exist in this group!");
 			}
 		}
 


### PR DESCRIPTION
I hope. 

Basically my last bug fix introduced a new one - launching back to a site immediately after recovering from it and no statics appearing.
So custom space centres code is temporarily disabled and a previousbug fix slightly reverted. It's testing fine here with the old bug not recurring but I don't trust it.

Update on out of Kerbin SOI launch issues also. I'm 99% certain this can't be fixed. KSP's spawn code does not work the same way that it does on Kerbin/Minmus/the Mun. This isn't a bug in KK as far as I am concerned - this is just a lacking feature. KK should not support launch sites out of Kerbin's SOI because I'm pretty sure it can't.
