### PR TITLE
Add support for one-time snap-to-surface via CFG files

### DIFF
--- a/src/KerbalKonstructs.cs
+++ b/src/KerbalKonstructs.cs
@@ -154,6 +154,8 @@ namespace KerbalKonstructs
 				KKAPI.addModelSetting("TonsStMax", new ConfigFloat());
 				KKAPI.addInstanceSetting("TonsStCurrent", new ConfigFloat());
 
+				// Snap to surface
+				KKAPI.addInstanceSetting("SnapToSurface", new ConfigGenericString());
 			// END Instance API ******
 
 			SpaceCenterManager.setKSC();
@@ -437,6 +439,16 @@ namespace KerbalKonstructs
 									Debug.Log("KK: All attempts at finding a launchpad transform have failed (╯°□°）╯︵ ┻━┻ This static isn't configured for KK properly. Tell the modder.");
 								}
 							}
+						}
+					}
+
+					if (obj.settings.ContainsKey("SnapToSurface"))
+					{
+						if (obj.getSetting("SnapToSurface").ToString().ToUpper() == "TRUE")
+						{
+						    var pqsc = ((CelestialBody)obj.getSetting("CelestialBody")).pqsController;
+						    obj.setSetting("RadiusOffset", 1.0f + (float)(pqsc.GetSurfaceHeight((Vector3)obj.getSetting("RadialPosition")) - pqsc.radius));
+						    obj.setSetting("SnapToSurface", "False");
 						}
 					}
 


### PR DESCRIPTION
I'm working on a tool that procedurally generates static objects for Kerbal Konstructs outside of KSP itself. These changes allow authors to specify that a particular object instance should be snapped to the terrain surface in situations where the ideal RadiusOffset is unknown. I'm open to simply distributing the tool with a modified build of Kerbal Konstructs that includes these changes, but since the changes are fully backwards compatible, it seems like this would possibly be a valuable addition to the original project.
